### PR TITLE
add create tag and push tag

### DIFF
--- a/main.go
+++ b/main.go
@@ -80,6 +80,18 @@ func main() {
 			EnvVar: "PLUGIN_MESSAGE",
 		},
 
+		cli.StringFlag{
+			Name:   "tag",
+			Usage:  "tag to create",
+			EnvVar: "PLUGIN_TAG,DRONE_TAG",
+		},
+
+		cli.StringFlag{
+			Name:   "tag-message",
+			Usage:  "tag message",
+			EnvVar: "PLUGIN_TAG_MESSAGE",
+		},
+
 		cli.BoolFlag{
 			Name:   "force",
 			Usage:  "force push to remote",
@@ -132,6 +144,8 @@ func run(c *cli.Context) error {
 			Branch:      c.String("branch"),
 			Path:        c.String("path"),
 			Message:     c.String("message"),
+			Tag:         c.String("tag"),
+			TagMessage:  c.String("tag-message"),
 			Force:       c.Bool("force"),
 			FollowTags:  c.Bool("followtags"),
 			SkipVerify:  c.Bool("skip-verify"),

--- a/plugin.go
+++ b/plugin.go
@@ -32,6 +32,8 @@ type (
 		Branch      string
 		Path        string
 		Message     string
+		Tag         string
+		TagMessage  string
 		Force       bool
 		FollowTags  bool
 		SkipVerify  bool
@@ -87,6 +89,14 @@ func (p *Plugin) Exec() error {
 			}
 		case "push":
 			if err := p.HandlePush(); err != nil {
+				return err
+			}
+		case "tag":
+			if err := p.HandleTag(); err != nil {
+				return err
+			}
+		case "push-tag":
+			if err := p.HandlePushTag(); err != nil {
 				return err
 			}
 		default:
@@ -219,5 +229,21 @@ func (p Plugin) HandlePush() error {
 		p.Config.Branch,
 		p.Config.Force,
 		p.Config.FollowTags,
+	))
+}
+
+// HandleTag creates a tag on the current commit.
+func (p Plugin) HandleTag() error {
+	return execute(repo.CreateTag(
+		p.Config.Tag,
+		p.Config.TagMessage,
+	))
+}
+
+// HandlePushTag pushes a tag to remote.
+func (p Plugin) HandlePushTag() error {
+	return execute(repo.RemotePushTag(
+		"origin",
+		p.Config.Tag,
 	))
 }

--- a/repo/remote.go
+++ b/repo/remote.go
@@ -54,3 +54,14 @@ func RemotePushNamedBranch(remote, localbranch string, branch string, force bool
 
 	return cmd
 }
+
+// RemotePushTag pushes a tag from local to a remote repo.
+func RemotePushTag(remote, tag string) *exec.Cmd {
+	cmd := exec.Command(
+		"git",
+		"push",
+		remote,
+		tag)
+
+	return cmd
+}

--- a/repo/tag.go
+++ b/repo/tag.go
@@ -1,0 +1,22 @@
+package repo
+
+import "os/exec"
+
+const defaultTagMessage = "Release"
+
+// CreateTag creates a new tag
+func CreateTag(tag string, msg string) *exec.Cmd {
+	if msg == "" {
+		msg = defaultTagMessage + " " + tag
+	}
+
+	cmd := exec.Command(
+		"git",
+		"tag",
+		tag,
+		"-m",
+		msg,
+	)
+
+	return cmd
+}


### PR DESCRIPTION
# Description

Add 

## tag action

- Create a tag on the current commitID
- Needs the string flag `tag` to be set
- Considers the string flag `tag-message` if set. If not set it will create "Release %tag%" as a tag message where `%tag` is the tag which has been set.
- The tag can be pushed together with the commit when setting the `followtags` flag
- The tag can also be pushed by the `push-tag`action

## push-tag action

- Provides a separate push action to only push a tag to the remote.